### PR TITLE
Solucion error sombreado iconos redes sociales

### DIFF
--- a/css/estilos.css
+++ b/css/estilos.css
@@ -83,25 +83,31 @@
 		.yt
 		{
 			color:#D92530;
+			text-shadow: 4px 4px 4px #A69F9F;
 		}
 		.fb{
 			color: #3D5999;
+			text-shadow: 4px 4px 4px #A69F9F;			
 		}
 		.twt
 		{
 			color: #54ABEE;
+			text-shadow: 4px 4px 4px #A69F9F;			
 		}
 		.gh
 		{
 			color: black;
+			text-shadow: 4px 4px 4px #A69F9F;			
 		}
 		.lk
 		{
 			color:#2897CE;
+			text-shadow: 4px 4px 4px #A69F9F;			
 		}
 		.git
 		{
 			color: #F04F33;
+			text-shadow: 4px 4px 4px #A69F9F;			
 		}
 
 		.instagram{ 
@@ -117,7 +123,9 @@
 			background: -webkit-linear-gradient(45deg, #f09433 0%,#e6683c 25%,#dc2743 50%,#cc2366 75%,#bc1888 100%); 
 			background: linear-gradient(45deg, #f09433 0%,#e6683c 25%,#dc2743 50%,#cc2366 75%,#bc1888 100%); 
 			filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#f09433', endColorstr='#bc1888',GradientType=1 );
+			text-shadow: 4px 4px 4px #A69F9F;			
 		}
+
 
 		.btn
 		{


### PR DESCRIPTION
# Error solucionado
**Sombreado de iconos de Redes Sociales**
Se encontraban planos y se le ha adicionado `text-shadow: 4px 4px 4px #A69F9F;` con lo cual ha quedado solucionado.